### PR TITLE
Fix missing import

### DIFF
--- a/higlass_manage/ingest.py
+++ b/higlass_manage/ingest.py
@@ -1,3 +1,4 @@
+import sys
 import click
 import os.path as op
 import tempfile


### PR DESCRIPTION
sys is referenced without being imported. When a user attempts to import a file that does not exist they get a stack trace instead of a "file not found" message due to the missing import.

## Description

What was changed in this pull request?

Added sys import

Why is it necessary?

sys is referenced in the code without being imported

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
