### PR TITLE
added --workers parameter to start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you want to make your instance accessible to the outside world, you need to s
 higlass-manage start --site-url higlass.io
 ```
 
-These commands will start an instance running on the default port of 8989. An alternate port can be specified using the ``--port`` parameter.
+These commands will start an instance running on the default port of 8989. An alternate port can be specified using the ``--port`` parameter. The number of worker processes for the uWSGI application server can be specified with the ``--workers`` parameter. 
 
 #### Setting default client options
 

--- a/higlass_manage/start.py
+++ b/higlass_manage/start.py
@@ -45,6 +45,9 @@ from higlass_manage.common import CONTAINER_PREFIX
 @click.option('--default-track-options',
         default=None,
         help="Specify a json file containing default track options")
+@click.option('--workers',
+        default=None,
+        help="Specify a custom number of workers for the uWSGI application server")
 def start(temp_dir,
             data_dir,
             version,
@@ -53,7 +56,8 @@ def start(temp_dir,
             site_url,
             media_dir,
             public_data,
-            default_track_options):
+            default_track_options,
+            workers):
     _start(temp_dir,
             data_dir,
             version,
@@ -62,7 +66,8 @@ def start(temp_dir,
             site_url,
             media_dir,
             public_data,
-            default_track_options)
+            default_track_options,
+            workers)
 
 def _start(temp_dir='/tmp/higlass-docker', 
         data_dir='~/hg-data', 
@@ -72,7 +77,8 @@ def _start(temp_dir='/tmp/higlass-docker',
         site_url=None,
         media_dir=None, 
         public_data=True,
-        default_track_options=None):
+        default_track_options=None,
+        workers=None):
     '''
     Start a HiGlass instance
     '''
@@ -115,6 +121,9 @@ def _start(temp_dir='/tmp/higlass-docker',
 
     if site_url is not None:
         environment['SITE_URL'] = site_url
+
+    if workers is not None:
+        environment['WORKERS'] = workers
 
     print('Data directory:', data_dir)
     print('Temp directory:', temp_dir)


### PR DESCRIPTION
## Description

What was changed in this pull request?

I added a `--workers` parameter to the `higlass-manage start` command. If specified, the `WORKERS` environment variable is set with the specified value and passed to the Python docker `run` call with other environment variables.

Why is it necessary?

I was using this to see what the effect would be on performance. It is not necessary but may be useful for others using `higlass-manage` to deploy a server.

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Updated CHANGELOG.md
