### PR TITLE
Redis container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,15 @@ If you want to make your instance accessible to the outside world, you need to s
 higlass-manage start --site-url higlass.io
 ```
 
-These commands will start an instance running on the default port of 8989. An alternate port can be specified using the ``--port`` parameter. The number of worker processes for the uWSGI application server can be specified with the ``--workers`` parameter. 
+These commands will start an instance running on the default port of 8989. An alternate port can be specified using the ``--port`` parameter. The number of worker processes for the uWSGI application server can be specified with the ``--workers`` parameter.
+
+#### Using the Redis caching service
+
+To make use of the Redis caching service to improve performance, add the `--use-redis` flag. Redis files will be stored by default in the `~/redis-data` directory. Add the `--redis-dir` parameter to override this default.
+
+```
+higlass-manage start ... --use-redis --redis-dir /new/path/to/redis-data
+```
 
 #### Setting default client options
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you want to make your instance accessible to the outside world, you need to s
 higlass-manage start --site-url higlass.io
 ```
 
-These commands will start an instance running on the default port of 8989. An alternate port can be specified using the ``--port`` parameter.
+These commands will start an instance running on the default port of 8989. An alternate port can be specified using the ``--port`` parameter. The number of worker processes for the uWSGI application server can be specified with the ``--workers`` parameter. 
 
 #### Setting default client options
 

--- a/higlass_manage/common.py
+++ b/higlass_manage/common.py
@@ -8,9 +8,7 @@ import sys
 CONTAINER_PREFIX = 'higlass-manage-container'
 NETWORK_PREFIX = 'higlass-manage-network'
 REDIS_PREFIX = 'higlass-manage-redis'
-REDIS_IMAGE = 'redis:5.0.3-alpine'
 REDIS_CONF = '/usr/local/etc/redis/redis.conf'
-REDIS_PORT = 6379
 
 def md5(fname):
     hash_md5 = hashlib.md5()

--- a/higlass_manage/common.py
+++ b/higlass_manage/common.py
@@ -6,7 +6,11 @@ import slugid
 import sys
 
 CONTAINER_PREFIX = 'higlass-manage-container'
-
+NETWORK_PREFIX = 'higlass-manage-network'
+REDIS_PREFIX = 'higlass-manage-redis'
+REDIS_IMAGE = 'redis:5.0.3-alpine'
+REDIS_CONF = '/usr/local/etc/redis/redis.conf'
+REDIS_PORT = 6379
 
 def md5(fname):
     hash_md5 = hashlib.md5()
@@ -17,6 +21,12 @@ def md5(fname):
 
 def hg_name_to_container_name(hg_name):
     return '{}-{}'.format(CONTAINER_PREFIX, hg_name)
+
+def hg_name_to_network_name(hg_name):
+    return '{}-{}'.format(NETWORK_PREFIX, hg_name)
+
+def hg_name_to_redis_name(hg_name):
+    return '{}-{}'.format(REDIS_PREFIX, hg_name)
 
 def get_port(hg_name):
     client = docker.from_env()
@@ -32,7 +42,7 @@ def fill_filetype_and_datatype(filename, filetype, datatype):
     If no filetype or datatype are provided, add them
     based on the given filename.
 
-    Paramters:
+    Parameters:
     ----------
     filename: str
         The name of the file

--- a/higlass_manage/list.py
+++ b/higlass_manage/list.py
@@ -1,3 +1,4 @@
+import sys
 import click
 import docker
 import json
@@ -20,12 +21,12 @@ def tilesets(hg_name):
     ret = requests.get(url)
 
     if ret.status_code != 200:
-        print('Error retrieving tilesets:', ret)
+        sys.stderr.write('Error retrieving tilesets: {}'.format(ret))
         return
 
     j = json.loads(ret.content.decode('utf8'))
     for result in j['results']:
-        print(" | ".join([result['uuid'], result['filetype'], result['datatype'], result['coordSystem'], result['name']]))
+        sys.stderr.write("{}\n".format(" | ".join([result['uuid'], result['filetype'], result['datatype'], result['coordSystem'], result['name']])))
 
 @click.command()
 def instances():
@@ -41,9 +42,9 @@ def instances():
             config = client.api.inspect_container(container.name)
             directories = " ".join( ['{}:{}'.format(m['Source'], m['Destination']) for m in  config['Mounts']])
             port = config['HostConfig']['PortBindings']['80/tcp'][0]['HostPort']
-            print(hm_name, "{} {}".format(directories, port))
+            sys.stderr.write("{} {} {}\n".format(hm_name, directories, port))
         if name.find(REDIS_PREFIX) == 0:
             redis_name = name[len(REDIS_PREFIX)+1:]
             redis_config = client.api.inspect_container(container.name)
             redis_directories = " ".join( ['{}:{}'.format(m['Source'], m['Destination']) for m in redis_config['Mounts']])
-            print(redis_name, "{}".format(redis_directories))
+            sys.stderr.write("{} {}\n".format(redis_name, redis_directories))

--- a/higlass_manage/list.py
+++ b/higlass_manage/list.py
@@ -4,7 +4,7 @@ import json
 import requests
 
 from higlass_manage.common import get_port
-from higlass_manage.common import CONTAINER_PREFIX
+from higlass_manage.common import CONTAINER_PREFIX, REDIS_PREFIX
 
 @click.command()
 @click.option('--hg-name', default='default', 
@@ -42,3 +42,8 @@ def instances():
             directories = " ".join( ['{}:{}'.format(m['Source'], m['Destination']) for m in  config['Mounts']])
             port = config['HostConfig']['PortBindings']['80/tcp'][0]['HostPort']
             print(hm_name, "{} {}".format(directories, port))
+        if name.find(REDIS_PREFIX) == 0:
+            redis_name = name[len(REDIS_PREFIX)+1:]
+            redis_config = client.api.inspect_container(container.name)
+            redis_directories = " ".join( ['{}:{}'.format(m['Source'], m['Destination']) for m in redis_config['Mounts']])
+            print(redis_name, "{}".format(redis_directories))

--- a/higlass_manage/list.py
+++ b/higlass_manage/list.py
@@ -26,7 +26,7 @@ def tilesets(hg_name):
 
     j = json.loads(ret.content.decode('utf8'))
     for result in j['results']:
-        sys.stderr.write("{}\n".format(" | ".join([result['uuid'], result['filetype'], result['datatype'], result['coordSystem'], result['name']])))
+        sys.stdout.write("{}\n".format(" | ".join([result['uuid'], result['filetype'], result['datatype'], result['coordSystem'], result['name']])))
 
 @click.command()
 def instances():
@@ -42,10 +42,10 @@ def instances():
             config = client.api.inspect_container(container.name)
             directories = " ".join( ['{}:{}'.format(m['Source'], m['Destination']) for m in  config['Mounts']])
             port = config['HostConfig']['PortBindings']['80/tcp'][0]['HostPort']
-            sys.stderr.write("higlass\t{}\t{}\t{}\n".format(hm_name, directories, port))
+            sys.stdout.write("higlass\t{}\t{}\t{}\n".format(hm_name, directories, port))
         if name.find(REDIS_PREFIX) == 0:
             redis_name = name[len(REDIS_PREFIX)+1:]
             redis_config = client.api.inspect_container(container.name)
             redis_directories = " ".join( ['{}:{}'.format(m['Source'], m['Destination']) for m in redis_config['Mounts']])
-            sys.stderr.write("redis\t{}\t{}\t.\n".format(redis_name, redis_directories))
+            sys.stdout.write("redis\t{}\t{}\t.\n".format(redis_name, redis_directories))
 

--- a/higlass_manage/list.py
+++ b/higlass_manage/list.py
@@ -42,9 +42,10 @@ def instances():
             config = client.api.inspect_container(container.name)
             directories = " ".join( ['{}:{}'.format(m['Source'], m['Destination']) for m in  config['Mounts']])
             port = config['HostConfig']['PortBindings']['80/tcp'][0]['HostPort']
-            sys.stderr.write("{} {} {}\n".format(hm_name, directories, port))
+            sys.stderr.write("higlass\t{}\t{}\t{}\n".format(hm_name, directories, port))
         if name.find(REDIS_PREFIX) == 0:
             redis_name = name[len(REDIS_PREFIX)+1:]
             redis_config = client.api.inspect_container(container.name)
             redis_directories = " ".join( ['{}:{}'.format(m['Source'], m['Destination']) for m in redis_config['Mounts']])
-            sys.stderr.write("{} {}\n".format(redis_name, redis_directories))
+            sys.stderr.write("redis\t{}\t{}\t.\n".format(redis_name, redis_directories))
+

--- a/higlass_manage/redis/redis.conf
+++ b/higlass_manage/redis/redis.conf
@@ -1,0 +1,4 @@
+maxmemory 8gb
+maxmemory-policy allkeys-lru
+logfile /data/redis.log
+activedefrag yes

--- a/higlass_manage/start.py
+++ b/higlass_manage/start.py
@@ -45,6 +45,9 @@ from higlass_manage.common import CONTAINER_PREFIX
 @click.option('--default-track-options',
         default=None,
         help="Specify a json file containing default track options")
+@click.option('--workers',
+        default=None,
+        help="Specify a custom number of workers for the uWSGI application server")
 def start(temp_dir,
             data_dir,
             version,
@@ -53,7 +56,8 @@ def start(temp_dir,
             site_url,
             media_dir,
             public_data,
-            default_track_options):
+            default_track_options,
+            workers):
     _start(temp_dir,
             data_dir,
             version,
@@ -62,7 +66,8 @@ def start(temp_dir,
             site_url,
             media_dir,
             public_data,
-            default_track_options)
+            default_track_options,
+            workers)
 
 def _start(temp_dir='/tmp/higlass-docker', 
         data_dir='~/hg-data', 
@@ -72,7 +77,8 @@ def _start(temp_dir='/tmp/higlass-docker',
         site_url=None,
         media_dir=None, 
         public_data=True,
-        default_track_options=None):
+        default_track_options=None,
+        workers=None):
     '''
     Start a HiGlass instance
     '''
@@ -115,6 +121,9 @@ def _start(temp_dir='/tmp/higlass-docker',
 
     if site_url is not None:
         environment['SITE_URL'] = site_url
+
+    if workers is not None:
+        environment['WORKERS'] = workers
 
     print('Data directory:', data_dir)
     print('Temp directory:', temp_dir)

--- a/higlass_manage/start.py
+++ b/higlass_manage/start.py
@@ -8,7 +8,7 @@ import slugid
 import sys
 import time
 
-from higlass_manage.common import CONTAINER_PREFIX
+from higlass_manage.common import CONTAINER_PREFIX, NETWORK_PREFIX, REDIS_PREFIX, REDIS_IMAGE, REDIS_CONF, REDIS_PORT
 
 @click.command()
 @click.option('-t', '--temp-dir',
@@ -48,50 +48,63 @@ from higlass_manage.common import CONTAINER_PREFIX
 @click.option('--workers',
         default=None,
         help="Specify a custom number of workers for the uWSGI application server")
+@click.option('--use-redis',
+              is_flag=True,
+              help="Initialize a Redis-based caching service and bind higlass instance to it")
+@click.option('--redis-dir',
+              default='~/redis-data',
+              help='Use a specific directory for Redis files',
+              type=str)
 def start(temp_dir,
-            data_dir,
-            version,
-            port,
-            hg_name,
-            site_url,
-            media_dir,
-            public_data,
-            default_track_options,
-            workers):
+          data_dir,
+          version,
+          port,
+          hg_name,
+          site_url,
+          media_dir,
+          public_data,
+          default_track_options,
+          workers,
+          use_redis,
+          redis_dir):
     _start(temp_dir,
-            data_dir,
-            version,
-            port,
-            hg_name,
-            site_url,
-            media_dir,
-            public_data,
-            default_track_options,
-            workers)
+           data_dir,
+           version,
+           port,
+           hg_name,
+           site_url,
+           media_dir,
+           public_data,
+           default_track_options,
+           workers,
+           use_redis,
+           redis_dir)
 
 def _start(temp_dir='/tmp/higlass-docker', 
-        data_dir='~/hg-data', 
-        version='latest', 
-        port=8989, 
-        hg_name='default', 
-        site_url=None,
-        media_dir=None, 
-        public_data=True,
-        default_track_options=None,
-        workers=None):
+           data_dir='~/hg-data', 
+           version='latest', 
+           port=8989, 
+           hg_name='default', 
+           site_url=None,
+           media_dir=None, 
+           public_data=True,
+           default_track_options=None,
+           workers=None,
+           use_redis=False,
+           redis_dir='~/redis-data'):
     '''
     Start a HiGlass instance
     '''
-    container_name = '{}-{}'.format(CONTAINER_PREFIX,hg_name)
+    hg_container_name = '{}-{}'.format(CONTAINER_PREFIX,hg_name)
 
     client = docker.from_env()
 
     try:
-        container = client.containers.get(container_name)
+        hg_container = client.containers.get(hg_container_name)
 
         print('Stopping previously running container')
-        container.stop()
-        container.remove()
+        hg_container.stop()
+        hg_container.remove()
     except docker.errors.NotFound:
         # container isn't running so no need to stop it
         pass
@@ -99,14 +112,90 @@ def _start(temp_dir='/tmp/higlass-docker',
         print('Error connecting to the Docker daemon, make sure it is started and you are logged in.')
         return
 
+    if use_redis:
+        network_name = '{}-{}'.format(NETWORK_PREFIX, hg_name)
+        redis_name = '{}-{}'.format(REDIS_PREFIX, hg_name)
+
+        # set up a bridge network for Redis and higlass containers to share
+        try:
+            network_list = client.networks.list(names=[network_name])
+            if network_list:
+                network = client.networks.get(network_name)
+                sys.stderr.write("Attempting to remove existing Docker network instance\n")
+                network.remove()
+        except docker.errors.APIError:
+            sys.stderr.write("Error: Could not access Docker network list to remove existing network.\n")
+            sys.exit(-1)            
+
+        try:
+            # https://docker-py.readthedocs.io/en/stable/networks.html
+            network = client.networks.create(network_name, driver="bridge")
+        except docker.errors.APIError:
+            sys.stderr.write("Error: Could not access Docker network.\n")
+            sys.exit(-1)
+
+        # clear up any running Redis container
+        try:
+            redis_container = client.containers.get(redis_name)
+            sys.stderr.write("Stopping previously running Redis container\n")
+            redis_container.stop()
+            redis_container.remove()
+        except docker.errors.NotFound:
+            pass
+        except requests.exceptions.ConnectionError:
+            sys.stderr.write("Error: Error connecting to the Docker daemon, make sure it is started and you are logged in.\n")
+            sys.exit(-1)
+
+        # pull Redis image
+        sys.stderr.write("Pulling {}\n".format(REDIS_IMAGE))
+        sys.stderr.flush()
+        redis_image = client.images.pull(REDIS_IMAGE)
+        sys.stderr.write("done\n")
+        sys.stderr.flush()
+
+        # set up Redis container settings and environment
+        redis_dir = op.expanduser(redis_dir)
+
+        if not op.exists(redis_dir):
+            os.makedirs(redis_dir)
+
+        redis_conf = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'redis', 'redis.conf')
+        if not os.path.exists(redis_conf):
+            sys.stderr.write("Error: Could not locate Redis configuration file [{}]\n".format(redis_conf))
+            sys.exit(-1)
+
+        redis_volumes = {
+            redis_dir : { 'bind' : '/data', 'mode' : 'rw' },
+            redis_conf : { 'bind' : REDIS_CONF, 'mode' : 'rw' }
+        }
+
+        redis_command = 'redis-server {}'.format(REDIS_CONF)
+
+        try:
+            # run Redis container
+            redis_container = client.containers.run(redis_image,
+                                                    redis_command,
+                                                    name=redis_name,
+                                                    network=network_name,
+                                                    volumes=redis_volumes,
+                                                    detach=True)
+        except docker.errors.ContainerError as err:
+            sys.stderr.write("Error: Redis container could not be started\n{}\n".format(err))
+            sys.exit(-1)
+        except docker.errors.ImageNotFound as err:
+            sys.stderr.write("Error: Redis container image could not be found\n{}\n".format(err))
+            sys.exit(-1)
+        except docker.errors.APIError as err:
+            sys.stderr.write("Error: Redis container server ran into a fatal error\n{}\n".format(err))
+            sys.exit(-1)
 
     if version == 'local':
-        image = client.images.get('image-default')
+        hg_image = client.images.get('image-default')
     else:
         sys.stdout.write("Pulling latest image... ")
         sys.stdout.flush()
-        image = client.images.pull('higlass/higlass-docker', version)
-        sys.stdout.write("done")
+        hg_image = client.images.pull('higlass/higlass-docker', version)
+        sys.stdout.write("done\n")
         sys.stdout.flush()
 
     data_dir = op.expanduser(data_dir)
@@ -117,37 +206,51 @@ def _start(temp_dir='/tmp/higlass-docker',
     if not op.exists(data_dir):
         os.makedirs(data_dir)
 
-    environment = {}
+    hg_environment = {}
 
     if site_url is not None:
-        environment['SITE_URL'] = site_url
+        hg_environment['SITE_URL'] = site_url
 
     if workers is not None:
-        environment['WORKERS'] = workers
+        hg_environment['WORKERS'] = workers
 
     print('Data directory:', data_dir)
     print('Temp directory:', temp_dir)
 
-    version_addition = '' if version is None else ':{}'.format(version)
+    hg_version_addition = '' if version is None else ':{}'.format(version)
 
     print('Starting...', hg_name, port)
-    volumes={
+    hg_volumes={
         temp_dir : { 'bind' : '/tmp', 'mode' : 'rw' },
         data_dir : { 'bind' : '/data', 'mode' : 'rw' }
         }
 
     if media_dir:
-        volumes[media_dir] = { 'bind' : '/media', 'mode' : 'rw' }
-        environment['HIGLASS_MEDIA_ROOT'] = '/media'
+        hg_volumes[media_dir] = { 'bind' : '/media', 'mode' : 'rw' }
+        hg_environment['HIGLASS_MEDIA_ROOT'] = '/media'
 
-
-    container = client.containers.run(image,
-            ports={80 : port},
-            volumes=volumes,
-            name=container_name,
-            environment=environment,
-            detach=True)
-    print('Docker started: {}'.format(container_name))
+    if not use_redis:
+        hg_container = client.containers.run(hg_image,
+                                             ports={80 : port},
+                                             volumes=hg_volumes,
+                                             name=hg_container_name,
+                                             environment=hg_environment,
+                                             detach=True)
+    else:
+        # add some environment variables to the higlass container
+        hg_environment['REDIS_HOST'] = redis_name
+        hg_environment['REDIS_PORT'] = REDIS_PORT
+        # run the higlass container on the shared network with the Redis container
+        hg_container = client.containers.run(hg_image,
+                                             network=network_name,
+                                             ports={80 : port},
+                                             volumes=hg_volumes,
+                                             name=hg_container_name,
+                                             environment=hg_environment,
+                                             publish_all_ports=True,
+                                             detach=True)
+        
+    print('Docker started: {}'.format(hg_container_name))
 
     started = False
     counter = 1
@@ -180,7 +283,7 @@ def _start(temp_dir='/tmp/higlass-docker',
 
         sed_command = """bash -c 'cp higlass-app/static/js/main.*.chunk.js higlass-app/static/js/main.{}.chunk.js'""".format(new_hash)
 
-        ret = container.exec_run(sed_command)   
+        ret = hg_container.exec_run(sed_command)   
              
     if not public_data:
         config = json.loads(req.content.decode('utf-8'))
@@ -192,11 +295,11 @@ def _start(temp_dir='/tmp/higlass-docker',
                 'viewconf': config
                 }
 
-        ret = container.exec_run("""python higlass-server/manage.py shell --command="import tilesets.models as tm; o = tm.ViewConf.objects.get(uuid='default_local'); o.delete();" """);
+        ret = hg_container.exec_run("""python higlass-server/manage.py shell --command="import tilesets.models as tm; o = tm.ViewConf.objects.get(uuid='default_local'); o.delete();" """);
         ret = requests.post('http://localhost:{}/api/v1/viewconfs/'.format(port), json=config)
         print('ret:', ret.content)
         # ret = container.exec_run('echo "import tilesets.models as tm; tm.ViewConf.get(uuid={}default{}).delete()" | python higlass-server/manage.py shell'.format("'", "'"), tty=True)
-        ret = container.exec_run("""bash -c 'sed -i '"'"'s/"default"/"default_local"/g'"'"' higlass-app/static/js/main.*.chunk.js'""".format(new_hash))
+        ret = hg_container.exec_run("""bash -c 'sed -i '"'"'s/"default"/"default_local"/g'"'"' higlass-app/static/js/main.*.chunk.js'""".format(new_hash))
         print('ret:', ret)
 
     if default_track_options is not None:
@@ -207,20 +310,20 @@ def _start(temp_dir='/tmp/higlass-docker',
             sed_command += " higlass-app/static/js/main.*.chunk.js'"
             # print("sed_command:", sed_command)
 
-            ret = container.exec_run(sed_command)
+            ret = hg_container.exec_run(sed_command)
 
     # print("ret:", ret)
 
     sed_command = """bash -c 'sed -i '"'"'s/main.*.chunk.js/main.invalid.chunk.js/g'"'"' """
     sed_command += " higlass-app/precache-manifest.*.js'"
 
-    ret = container.exec_run(sed_command)
+    ret = hg_container.exec_run(sed_command)
     # print("ret:", ret)
 
     sed_command = """bash -c 'sed -i '"'"'s/index.html/index_invalidated_by_higlass_manage/g'"'"' """
     sed_command += " higlass-app/precache-manifest.*.js'"
 
-    ret = container.exec_run(sed_command)
+    ret = hg_container.exec_run(sed_command)
     # print("ret:", ret)
     print("Replaced js file")
 

--- a/higlass_manage/stop.py
+++ b/higlass_manage/stop.py
@@ -22,7 +22,7 @@ def stop(names):
             client.containers.get(hm_name).stop()
             client.containers.get(hm_name).remove()
         except docker.errors.NotFound as ex:
-            sys.stderr.write("Instance not running: {}".format(name))
+            sys.stderr.write("Instance not running: {}\n".format(name))
             
         # redis container
         redis_name = '{}-{}'.format(REDIS_PREFIX, name)
@@ -30,7 +30,7 @@ def stop(names):
             client.containers.get(redis_name).stop()
             client.containers.get(redis_name).remove()
         except docker.errors.NotFound:
-            sys.stderr.write("No Redis instances found at {}; skipping...".format(redis_name))
+            sys.stderr.write("No Redis instances found at {}; skipping...\n".format(redis_name))
             
         # bridge network
         network_name = '{}-{}'.format(NETWORK_PREFIX, name)
@@ -40,5 +40,5 @@ def stop(names):
                 network = client.networks.get(network_name)
                 network.remove()
         except docker.errors.NotFound:
-            sys.stderr.write("No bridge network found at {}; skipping...".format(network_name))
+            sys.stderr.write("No bridge network found at {}; skipping...\n".format(network_name))
         

--- a/higlass_manage/stop.py
+++ b/higlass_manage/stop.py
@@ -1,3 +1,4 @@
+import sys
 import click
 import docker
 
@@ -21,7 +22,7 @@ def stop(names):
             client.containers.get(hm_name).stop()
             client.containers.get(hm_name).remove()
         except docker.errors.NotFound as ex:
-            print("Instance not running: {}".format(name))
+            sys.stderr.write("Instance not running: {}".format(name))
             
         # redis container
         redis_name = '{}-{}'.format(REDIS_PREFIX, name)

--- a/higlass_manage/stop.py
+++ b/higlass_manage/stop.py
@@ -1,7 +1,7 @@
 import click
 import docker
 
-from .common import CONTAINER_PREFIX
+from .common import CONTAINER_PREFIX, NETWORK_PREFIX, REDIS_PREFIX
 
 @click.command()
 @click.argument('names', nargs=-1)
@@ -15,10 +15,29 @@ def stop(names):
         names = ('default',)
 
     for name in names:
+        # higlass container
         hm_name = '{}-{}'.format(CONTAINER_PREFIX, name)
-
         try:
             client.containers.get(hm_name).stop()
             client.containers.get(hm_name).remove()
         except docker.errors.NotFound as ex:
             print("Instance not running: {}".format(name))
+            
+        # redis container
+        redis_name = '{}-{}'.format(REDIS_PREFIX, name)
+        try:
+            client.containers.get(redis_name).stop()
+            client.containers.get(redis_name).remove()
+        except docker.errors.NotFound:
+            sys.stderr.write("No Redis instances found at {}; skipping...".format(redis_name))
+            
+        # bridge network
+        network_name = '{}-{}'.format(NETWORK_PREFIX, name)
+        try:
+            network_list = client.networks.list(names=[network_name])
+            if network_list:
+                network = client.networks.get(network_name)
+                network.remove()
+        except docker.errors.NotFound:
+            sys.stderr.write("No bridge network found at {}; skipping...".format(network_name))
+        

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ setup(
     version='0.6.1',
     py_modules=['higlass_manage'],
     packages=['higlass_manage'],
+    package_data={'': ['redis/*']},
+    include_package_data=True,
     install_requires=[
         'Click',
         'clodius>=0.10.3',

--- a/test.sh
+++ b/test.sh
@@ -11,8 +11,8 @@ die() { set +v; echo "$*" 1>&2 ; sleep 1; exit 1; }
 TMPDIR=$(mktemp -d)
 
 # Make sure it gets removed even if the script exits abnormally
-trap "exit 1"           HUP INT PIPE QUIT TERM
-trap 'rm -rf "$TMPDIR"' EXIT
+#trap "exit 1"           HUP INT PIPE QUIT TERM
+#trap 'rm -rf "$TMPDIR"' EXIT
 
 start get-data
     ./get_test_data.sh

--- a/test.sh
+++ b/test.sh
@@ -75,7 +75,9 @@ start redis
     mkdir ${TMPDIR}/test-hg-media-with-redis
     mkdir ${TMPDIR}/test-redis
 
+    PORT=8124
     higlass-manage start --version $HIGLASS_DOCKER_VERSION \
+		   --port ${PORT} \
 		   --hg-name test-hg-with-redis \
 		   --data-dir ${TMPDIR}/test-hg-data-with-redis \
 		   --media-dir ${TMPDIR}/test-hg-media-with-redis \

--- a/test.sh
+++ b/test.sh
@@ -60,6 +60,28 @@ start wait
         || die
 end wait
 
+start cleanup
+    higlass-manage stop test-hg
+end cleanup
+
+start redis
+    [ -e test-hg-data ] && rm -rf test-hg-data
+    [ -e test-hg-media ] && rm -rf test-hg-media
+    [ -e test-redis ] && rm -rf test-redis
+
+    mkdir test-hg-data
+    mkdir test-hg-media
+    mkdir test-redis
+
+    higlass-manage start --version $HIGLASS_DOCKER_VERSION \
+		   --hg-name test-hg \
+		   --data-dir $(pwd)/test-hg-data \
+		   --media-dir $(pwd)/test-hg-media \
+		   --redis-dir $(pwd)/test-redis \
+		   --use-redis
+
+    docker exec -i higlass-manage-redis-default 'redis-cli' < <(echo ping) || die
+end redis
 
 start cleanup
     higlass-manage stop test-hg

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ die() { set +v; echo "$*" 1>&2 ; sleep 1; exit 1; }
 TMPDIR=$(mktemp --directory --tmpdir=${HOME})
 
 # Make sure it gets removed even if the script exits abnormally
-trap "exit 1"           HUP INT PIPE QUIT TERM
+#trap "exit 1"           HUP INT PIPE QUIT TERM
 trap 'rm -rf "$TMPDIR"' EXIT
 
 start get-data

--- a/test.sh
+++ b/test.sh
@@ -16,8 +16,8 @@ HIGLASS_DOCKER_VERSION=v0.6.9;
 
 
 start ingest
-    [ -e test-hg-data ] && rm -rf test-hg-data
-    [ -e test-hg-media ] && rm -rf test-hg-media
+    [ -e $(PWD)/test-hg-data ] && rm -rf $(PWD)/test-hg-data
+    [ -e $(PWD)/test-hg-media ] && rm -rf $(PWD)/test-hg-media
 
     # ingest a bedfile; useful for testing the aggregate
     # function that gets called first
@@ -26,19 +26,19 @@ start ingest
         data/ctcf_known1_100.bed
 
     # directories that will store data and media
-    mkdir test-hg-data
-    mkdir test-hg-media
+    mkdir $(PWD)/test-hg-data
+    mkdir $(PWD)/test-hg-media
 
     cp data/Dixon2012-J1-NcoI-R1-filtered.100kb.multires.cool \
-       test-hg-media/dixon.mcool
+       $(PWD)/test-hg-media/dixon.mcool
 
-    higlass-manage view test-hg-media/dixon.mcool
+    higlass-manage view $(PWD)/test-hg-media/dixon.mcool
 
     PORT=8123
     higlass-manage start --version $HIGLASS_DOCKER_VERSION --port $PORT \
                                    --hg-name test-hg \
-                                   --data-dir $(pwd)/test-hg-data \
-                                   --media-dir $(pwd)/test-hg-media
+                                   --data-dir $(PWD)/test-hg-data \
+                                   --media-dir $(PWD)/test-hg-media
     higlass-manage ingest --hg-name test-hg \
                                     --no-upload /media/dixon.mcool \
                                     --uid a
@@ -65,9 +65,9 @@ start cleanup
 end cleanup
 
 start redis
-    [ -e test-hg-data ] && rm -rf test-hg-data
-    [ -e test-hg-media ] && rm -rf test-hg-media
-    [ -e test-redis ] && rm -rf test-redis
+    [ -e $(PWD)/test-hg-data ] && rm -rf $(PWD)/test-hg-data
+    [ -e $(PWD)/test-hg-media ] && rm -rf $(PWD)/test-hg-media
+    [ -e $(PWD)/test-redis ] && rm -rf $(PWD)/test-redis
 
     mkdir test-hg-data
     mkdir test-hg-media
@@ -75,9 +75,9 @@ start redis
 
     higlass-manage start --version $HIGLASS_DOCKER_VERSION \
 		   --hg-name test-hg \
-		   --data-dir $(pwd)/test-hg-data \
-		   --media-dir $(pwd)/test-hg-media \
-		   --redis-dir $(pwd)/test-redis \
+		   --data-dir $(PWD)/test-hg-data \
+		   --media-dir $(PWD)/test-hg-media \
+		   --redis-dir $(PWD)/test-redis \
 		   --use-redis
 
     docker exec -i higlass-manage-redis-default 'redis-cli' < <(echo ping) || die

--- a/test.sh
+++ b/test.sh
@@ -7,12 +7,13 @@ die() { set +v; echo "$*" 1>&2 ; sleep 1; exit 1; }
 # Race condition truncates logs on Travis: "sleep" might help.
 # https://github.com/travis-ci/travis-ci/issues/6018
 
-# Create temporary work directory
-TMPDIR=$(mktemp -d)
+# Due to Travis CI permissions, create temporary work
+# directory that is relative to the home directory
+TMPDIR=$(mktemp --directory --tmpdir=${HOME})
 
 # Make sure it gets removed even if the script exits abnormally
-#trap "exit 1"           HUP INT PIPE QUIT TERM
-#trap 'rm -rf "$TMPDIR"' EXIT
+trap "exit 1"           HUP INT PIPE QUIT TERM
+trap 'rm -rf "$TMPDIR"' EXIT
 
 start get-data
     ./get_test_data.sh

--- a/test.sh
+++ b/test.sh
@@ -20,7 +20,6 @@ end get-data
 
 HIGLASS_DOCKER_VERSION=v0.6.9;
 
-
 start ingest
     [ -e ${TMPDIR}/test-hg-data ] && rm -rf ${TMPDIR}/test-hg-data
     [ -e ${TMPDIR}/test-hg-media ] && rm -rf ${TMPDIR}/test-hg-media
@@ -84,7 +83,7 @@ start redis
 		   --redis-dir ${TMPDIR}/test-redis \
 		   --use-redis
 
-    docker exec -i higlass-manage-redis-default 'redis-cli' < <(echo ping) || die
+    docker exec -i higlass-manage-redis-test-hg-with-redis 'redis-cli' < <(echo ping) || die
 end redis
 
 start cleanup

--- a/test.sh
+++ b/test.sh
@@ -71,18 +71,14 @@ start cleanup
 end cleanup
 
 start redis
-    [ -e ${TMPDIR}/test-hg-data ] && rm -rf ${TMPDIR}/test-hg-data
-    [ -e ${TMPDIR}/test-hg-media ] && rm -rf ${TMPDIR}/test-hg-media
-    [ -e ${TMPDIR}/test-redis ] && rm -rf ${TMPDIR}/test-redis
-
-    mkdir ${TMPDIR}/test-hg-data
-    mkdir ${TMPDIR}/test-hg-media
+    mkdir ${TMPDIR}/test-hg-data-with-redis
+    mkdir ${TMPDIR}/test-hg-media-with-redis
     mkdir ${TMPDIR}/test-redis
 
     higlass-manage start --version $HIGLASS_DOCKER_VERSION \
-		   --hg-name test-hg \
-		   --data-dir ${TMPDIR}/test-hg-data \
-		   --media-dir ${TMPDIR}/test-hg-media \
+		   --hg-name test-hg-with-redis \
+		   --data-dir ${TMPDIR}/test-hg-data-with-redis \
+		   --media-dir ${TMPDIR}/test-hg-media-with-redis \
 		   --redis-dir ${TMPDIR}/test-redis \
 		   --use-redis
 
@@ -90,7 +86,7 @@ start redis
 end redis
 
 start cleanup
-    higlass-manage stop test-hg
+    higlass-manage stop test-hg-with-redis
 end cleanup
 
 echo 'Passed all tests'

--- a/test.sh
+++ b/test.sh
@@ -13,7 +13,7 @@ TMPDIR=$(mktemp --directory --tmpdir=${HOME})
 
 # Make sure it gets removed even if the script exits abnormally
 #trap "exit 1"           HUP INT PIPE QUIT TERM
-trap 'rm -rf "$TMPDIR"' EXIT
+#trap 'rm -rf "$TMPDIR"' EXIT
 
 start get-data
     ./get_test_data.sh

--- a/test.sh
+++ b/test.sh
@@ -11,10 +11,6 @@ die() { set +v; echo "$*" 1>&2 ; sleep 1; exit 1; }
 # directory that is relative to the home directory
 TMPDIR=$(mktemp --directory --tmpdir=${HOME})
 
-# Make sure it gets removed even if the script exits abnormally
-#trap "exit 1"           HUP INT PIPE QUIT TERM
-#trap 'rm -rf "$TMPDIR"' EXIT
-
 start get-data
     ./get_test_data.sh
 end get-data


### PR DESCRIPTION
## Description

What was changed in this pull request?

To improve the default performance of the higlass container instance, I added code to instantiate a Redis container alongside a higlass container, on a bridge network within the Docker environment. 

This adds `--use-redis` and `--redis-dir` parameters to turn on Redis support and to specify a custom Redis data directory.

I used the `higlass-docker` `start_production.sh` script as a template for the settings used to instantiate the Redis image and configuration: https://github.com/higlass/higlass-docker/blob/master/start_production.sh

Why is it necessary?

Along with `--workers`, the default performance of a higlass instance may be helped with the option to add in-memory caching, to be able to allow others to more easily use `higlass-manage` to deploy a production service that is closer in speed to what the Docker images offer.

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Updated CHANGELOG.md
