### PR TITLE
Add extra column to list tilesets output

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ either the `--assembly` or `--chromsizes-filename` parameters.
 
 ```
 pete@twok:~/projects/higlass-manage$ higlass-manage list tilesets
-VlWKy6ofT6qMFGf-uG_5pQ | beddb | bedlike | GSE93955_CHIP_DMC1_B6_peaks.bed.multires
-LAXFhHhASa2zDgJRRS67cw | cooler | matrix | H3K27me3_HiChIP_1.multi.cool
+VlWKy6ofT6qMFGf-uG_5pQ | beddb | bedlike |  | GSE93955_CHIP_DMC1_B6_peaks.bed.multires
+LAXFhHhASa2zDgJRRS67cw | cooler | matrix |  | H3K27me3_HiChIP_1.multi.cool
 ```
 
 ### Starting a shell


### PR DESCRIPTION
## Description

What was changed in this pull request?
- tweak readme

Why is it necessary?
- Make it match what I actually see on the command line
```
$ higlass-manage list tilesets
YFkVEOCtR_6w8HCkpdyAMg | cooler | matrix |  | 4DNFI2A4OBS9.mcool
cLS4ksyCRq27Jc8jFQl17A | cooler | matrix |  | hic-resolutions.cool
```
(Alternatively, we could get rid of the extra column...)

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
