### PR TITLE
pin each un-pinned dependency to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ higlass-python==0.1.13
 docker==4.0.2
 ipywidgets==7.5.1
 slugid==2.0.0
+cooler==0.7.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-clodius>=0.10.3
-higlass-python>=0.1.1
-docker
-ipywidgets
+clodius==0.10.3
+higlass-python==0.1.13
+docker==4.0.2
+ipywidgets==7.5.1
 slugid==2.0.0


### PR DESCRIPTION
## Description

Pin dependencies to latest versions. Believe that this will fail because the higlass-python interface has changed, so just a draft for now.

(In a separate branch, I've pinned to the [lowest possible version](https://github.com/higlass/higlass-manage/compare/mccalluc/pin-dependencies?expand=1), but that's not working either.)

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
