### PR TITLE
Use the new higlass-python api for viewing viewconfs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+
+v0.7.3
+
+- Use the new higlass-python API
+
 v0.7.2
 
 - Added MANIFEST.in including redis.conf file

--- a/higlass_manage/view.py
+++ b/higlass_manage/view.py
@@ -111,7 +111,7 @@ def view(filename, hg_name, filetype, datatype, tracktype, position, public_data
         # couldn't ingest the file
         return
 
-    import higlass.client as hgc
+    from higlass.client import Track, View, ViewConf
 
     if datatype is None:
         datatype = inferred_datatype
@@ -123,15 +123,18 @@ def view(filename, hg_name, filetype, datatype, tracktype, position, public_data
             print("ERROR: Unknown track type for the given datatype:", datatype)
             return
 
-    conf = hgc.ViewConf()
-    view = conf.add_view()
+    view = View([
+        Track(track_type=tracktype, position=position,
+          tileset_uuid=uuid,
+          server='http://localhost:{}/api/v1/'.format(port),
+          height=200),
+    ])
 
-    track = view.add_track(track_type=tracktype,
-            server='http://localhost:{}/api/v1/'.format(port),
-            tileset_uuid=uuid, position=position, 
-            height=200)
+    viewconf = ViewConf(
+        [view]
+    )
 
-    conf = json.loads(json.dumps(conf.to_dict()))
+    conf = viewconf.to_dict()
 
     conf['trackSourceServers'] = []
     conf['trackSourceServers'] += ['http://localhost:{}/api/v1/'.format(port)]

--- a/higlass_manage/view.py
+++ b/higlass_manage/view.py
@@ -125,9 +125,9 @@ def view(filename, hg_name, filetype, datatype, tracktype, position, public_data
 
     view = View([
         Track(track_type=tracktype, position=position,
-          tileset_uuid=uuid,
-          server='http://localhost:{}/api/v1/'.format(port),
-          height=200),
+              tileset_uuid=uuid,
+              server='http://localhost:{}/api/v1/'.format(port),
+              height=200),
     ])
 
     viewconf = ViewConf(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-clodius>=0.10.3
-higlass-python>=0.1.1
-docker
-ipywidgets
+clodius==0.10.13
+higlass-python==0.1.13
+docker==4.0.2
+ipywidgets==7.5.1
 slugid==2.0.0


### PR DESCRIPTION
(Towards #38, #39: Requires new release to pypi.)

## Description

What was changed in this pull request?

Use the new higlass-python API.

Why is it necessary?

So that `higlass-manage view` doesn't fail.

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Updated CHANGELOG.md
