### PR TITLE
data-dir argument and hg-name option

### DIFF
--- a/higlass_manage/browse.py
+++ b/higlass_manage/browse.py
@@ -6,6 +6,7 @@ import webbrowser
 
 from higlass_manage.common import get_port
 
+
 @click.command()
 @click.argument('names', nargs=-1)
 def browse(names):

--- a/higlass_manage/cli.py
+++ b/higlass_manage/cli.py
@@ -1,5 +1,6 @@
 import click
 
+from higlass_manage import __version__
 from higlass_manage.ingest import ingest
 from higlass_manage.list import tilesets, instances
 from higlass_manage.start import start
@@ -7,37 +8,42 @@ from higlass_manage.stop import stop
 from higlass_manage.shell import shell
 from higlass_manage.view import view
 from higlass_manage.logs import logs
-from higlass_manage import __version__
+from higlass_manage.create import superuser as create_superuser
+from higlass_manage.delete import superuser as delete_superuser
 
-import higlass_manage.create as hmce
-import higlass_manage.delete as hmde
-
-@click.command()
-def version():
-    print(__version__)
 
 @click.group()
 def list():
-    pass
+    """
+    List instances or datasets
+    """
+
 
 list.add_command(tilesets)
 list.add_command(instances)
+
 
 @click.group()
 def create():
     pass
 
-create.add_command(hmce.superuser)
+
+create.add_command(create_superuser)
+
 
 @click.group()
 def delete():
     pass
 
-delete.add_command(hmde.superuser)
 
+delete.add_command(delete_superuser)
+
+
+@click.version_option(__version__, "-V", "--version")
 @click.group()
 def cli():
     pass
+
 
 cli.add_command(create)
 cli.add_command(delete)
@@ -48,4 +54,3 @@ cli.add_command(stop)
 cli.add_command(shell)
 cli.add_command(view)
 cli.add_command(logs)
-cli.add_command(version)

--- a/higlass_manage/common.py
+++ b/higlass_manage/common.py
@@ -10,6 +10,7 @@ NETWORK_PREFIX = 'higlass-manage-network'
 REDIS_PREFIX = 'higlass-manage-redis'
 REDIS_CONF = '/usr/local/etc/redis/redis.conf'
 
+
 def md5(fname):
     hash_md5 = hashlib.md5()
     with open(fname, "rb") as f:
@@ -17,14 +18,18 @@ def md5(fname):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
 
+
 def hg_name_to_container_name(hg_name):
     return '{}-{}'.format(CONTAINER_PREFIX, hg_name)
+
 
 def hg_name_to_network_name(hg_name):
     return '{}-{}'.format(NETWORK_PREFIX, hg_name)
 
+
 def hg_name_to_redis_name(hg_name):
     return '{}-{}'.format(REDIS_PREFIX, hg_name)
+
 
 def get_port(hg_name):
     client = docker.from_env()
@@ -34,6 +39,7 @@ def get_port(hg_name):
     port = config['HostConfig']['PortBindings']['80/tcp'][0]['HostPort']
 
     return port
+
 
 def fill_filetype_and_datatype(filename, filetype, datatype):
     '''
@@ -65,7 +71,7 @@ def fill_filetype_and_datatype(filename, filetype, datatype):
             print('Unknown filetype, please specify using the --filetype option', file=sys.stderr)
             if recommended_filetype is not None:
                 print("Based on the filename, you may want to try the filetype: {}".format(recommended_filetype))
-            
+
             return (None, None)
 
     if datatype is None:
@@ -80,6 +86,7 @@ def fill_filetype_and_datatype(filename, filetype, datatype):
 
     return (filetype, datatype)
 
+
 def recommend_filetype(filename):
     ext = op.splitext(filename)
     if op.splitext(filename)[1] == '.bed':
@@ -87,9 +94,11 @@ def recommend_filetype(filename):
     if op.splitext(filename)[1] == '.bedpe':
         return 'bedpe'
 
+
 def recommend_datatype(filetype):
     if filetype == 'bedfile':
         return 'bedlike'
+
 
 def datatype_to_tracktype(datatype):
     if datatype == 'matrix':
@@ -107,8 +116,9 @@ def datatype_to_tracktype(datatype):
 
     return (None, None)
 
+
 def infer_filetype(filename):
-    _,ext = op.splitext(filename)
+    _, ext = op.splitext(filename)
 
     if ext.lower() == '.bw' or ext.lower() == '.bigwig':
         return 'bigwig'
@@ -123,6 +133,7 @@ def infer_filetype(filename):
 
     return None
 
+
 def infer_datatype(filetype):
     if filetype == 'cooler':
         return 'matrix'
@@ -135,13 +146,14 @@ def infer_datatype(filetype):
     if filetype == 'beddb':
         return 'bedlike'
 
+
 def import_file(hg_name, filepath, filetype, datatype, assembly, name, uid, no_upload, project_name):
     # get this container's temporary directory
     if not no_upload:
         temp_dir = get_temp_dir(hg_name)
         if not op.exists(temp_dir):
             os.makedirs(temp_dir)
-            
+
         filename = op.split(filepath)[1]
         to_import_path = op.join(temp_dir, filename)
 
@@ -188,12 +200,12 @@ def import_file(hg_name, filepath, filetype, datatype, assembly, name, uid, no_u
 
     (exit_code, output) = container.exec_run(command)
 
-
     if exit_code != 0:
         print("ERROR:", output.decode('utf8'), file=sys.stderr)
         return None
 
     return uid
+
 
 def get_temp_dir(hg_name):
     client = docker.from_env()
@@ -209,6 +221,7 @@ def get_temp_dir(hg_name):
         if mount['Destination'] == '/tmp':
             return mount['Source']
 
+
 def get_data_dir(hg_name):
     client = docker.from_env()
     container_name = hg_name_to_container_name(hg_name)
@@ -217,6 +230,7 @@ def get_data_dir(hg_name):
     for mount in config['Mounts']:
         if mount['Destination'] == '/data':
             return mount['Source']
+
 
 class HiGlassNotRunningException(Exception):
     pass

--- a/higlass_manage/create.py
+++ b/higlass_manage/create.py
@@ -3,9 +3,12 @@ import subprocess as sp
 
 from higlass_manage.common import hg_name_to_container_name
 
+
 @click.command()
-@click.option('--hg-name', default='default', 
-        help='The name of the higlass container to import this file to')
+@click.option(
+    '-n', '--hg-name',
+    default='default',
+    help='The name of the higlass container to import this file to')
 def superuser(hg_name):
     '''
     Create a superuser in the container

--- a/higlass_manage/delete.py
+++ b/higlass_manage/delete.py
@@ -3,10 +3,13 @@ import subprocess as sp
 
 from higlass_manage.common import hg_name_to_container_name
 
+
 @click.command()
 @click.argument('username')
-@click.option('--hg-name', default='default', 
-        help='The name of the higlass container to import this file to')
+@click.option(
+    '-n', '--hg-name',
+    default='default',
+    help='The name of the higlass container to import this file to')
 def superuser(username, hg_name):
     '''
     Delete a superuser in the container

--- a/higlass_manage/ingest.py
+++ b/higlass_manage/ingest.py
@@ -9,58 +9,95 @@ from higlass_manage.common import import_file
 from higlass_manage.common import get_temp_dir
 from higlass_manage.start import _start
 
+
 @click.command()
 @click.argument('filename')
-@click.option('--hg-name', default='default', 
-        help='The name of the higlass container to import this file to')
-@click.option('--filetype', default=None, help="The type of file to ingest (e.g. cooler)")
-@click.option('--datatype', default=None, help="The data type of in the input file (e.g. matrix)")
-@click.option('--assembly', default=None, help="The assembly that this data is mapped to")
-@click.option('--name', default=None, help="The name to use for this file")
-@click.option('--uid', default=None, help='The uuid to use for this file')
-@click.option('--no-upload', default=None, is_flag=True, help="Do not copy the file to the media directory. File must already be in the media directory.")
-@click.option('--chromsizes-filename', default=None, help="A set of chromosome sizes to use for bed and bedpe files")
-@click.option('--has-header', default=False, is_flag=True, help="Does the input file have column header information (only relevant for bed or bedpe files)")
-@click.option('--project-name', default=None, help='Group this tileset with others by specifying a project name')
-def ingest(filename, 
-        hg_name, 
-        filetype=None, 
-        datatype=None, 
-        assembly=None, 
-        name=None, 
-        chromsizes_filename=None, 
-        has_header=False, 
-        uid=None, 
-        no_upload=None,
-        project_name=None):
+@click.option(
+    '-n', '--hg-name',
+    default='default',
+    help='The name of the higlass container to import this file to')
+@click.option(
+    '--filetype',
+    default=None,
+    help="The type of file to ingest (e.g. cooler)")
+@click.option(
+    '--datatype',
+    default=None,
+    help="The data type of in the input file (e.g. matrix)")
+@click.option(
+    '--assembly',
+    default=None,
+    help="The assembly that this data is mapped to")
+@click.option(
+    '--display-name',
+    default=None,
+    help="The name to use for this file")
+@click.option(
+    '--uid',
+    default=None,
+    help='The uuid to use for this file')
+@click.option(
+    '--no-upload',
+    default=None,
+    is_flag=True,
+    help="Do not copy the file to the media directory. File must already be in the media directory.")
+@click.option(
+    '--chromsizes-filename',
+    default=None,
+    help="A set of chromosome sizes to use for bed and bedpe files")
+@click.option(
+    '--has-header',
+    default=False,
+    is_flag=True,
+    help="Does the input file have column header information (only relevant for bed or bedpe files)")
+@click.option(
+    '--project-name',
+    default=None,
+    help='Group this tileset with others by specifying a project name')
+def ingest(
+    filename,
+    hg_name,
+    filetype=None,
+    datatype=None,
+    assembly=None,
+    name=None,
+    chromsizes_filename=None,
+    has_header=False,
+    uid=None,
+    no_upload=None,
+    project_name=None
+):
     '''
     Ingest a dataset
     '''
-    _ingest(filename,
-            hg_name,
-            filetype,
-            datatype,
-            assembly,
-            name,
-            chromsizes_filename,
-            has_header,
-            uid,
-            no_upload,
-            project_name
-            )
+    _ingest(
+        filename,
+        hg_name,
+        filetype,
+        datatype,
+        assembly,
+        name,
+        chromsizes_filename,
+        has_header,
+        uid,
+        no_upload,
+        project_name
+    )
 
-def _ingest(filename, 
-        hg_name, 
-        filetype=None, 
-        datatype=None, 
-        assembly=None, 
-        name=None, 
-        chromsizes_filename=None, 
-        has_header=False, 
-        uid=None, 
-        no_upload=None,
-        project_name=None):
 
+def _ingest(
+    filename,
+    hg_name,
+    filetype=None,
+    datatype=None,
+    assembly=None,
+    name=None,
+    chromsizes_filename=None,
+    has_header=False,
+    uid=None,
+    no_upload=None,
+    project_name=None
+):
     try:
         get_temp_dir(hg_name)
     except Exception:
@@ -73,17 +110,26 @@ def _ingest(filename,
 
     # guess filetype and datatype if they're None
     (filetype, datatype) = fill_filetype_and_datatype(filename, filetype, datatype)
-    
+
     temp_dir = get_temp_dir(hg_name)
     (to_import, filetype) = aggregate_file(filename, filetype, assembly, chromsizes_filename, has_header, no_upload, temp_dir)
 
     return import_file(hg_name, to_import, filetype, datatype, assembly, name, uid, no_upload, project_name)
 
-def aggregate_file(filename, filetype, assembly, chromsizes_filename, has_header, no_upload, tmp_dir):
+
+def aggregate_file(
+    filename,
+    filetype,
+    assembly,
+    chromsizes_filename,
+    has_header,
+    no_upload,
+    tmp_dir
+):
     if filetype == 'bedfile':
         if no_upload:
             raise Exception("Bedfile files need to be aggregated and cannot be linked. Consider not using the --link-file option", file=sys.stderr)
-            
+
         if assembly is None and chromsizes_filename is None:
             print('An assembly or set of chromosome sizes is required when importing bed files. Please specify one or the other using the --assembly or --chromsizes-filename parameters', file=sys.stderr)
             return
@@ -91,23 +137,26 @@ def aggregate_file(filename, filetype, assembly, chromsizes_filename, has_header
         output_file = op.join(tmp_dir, ntpath.basename(filename) + '.beddb')
 
         print("Aggregating bedfile")
-        cca._bedfile(filename,
-                output_file,
-                assembly,
-                importance_column='random',
-                has_header=has_header,
-                chromosome=None,
-                max_per_tile=50,
-                delimiter=None,
-                chromsizes_filename=chromsizes_filename,
-                offset=0,
-                tile_size=1024)
+        cca._bedfile(
+            filename,
+            output_file,
+            assembly,
+            importance_column='random',
+            has_header=has_header,
+            chromosome=None,
+            max_per_tile=50,
+            delimiter=None,
+            chromsizes_filename=chromsizes_filename,
+            offset=0,
+            tile_size=1024
+        )
 
         to_import = output_file
 
         # because we aggregated the file, the new filetype is beddb
-        filetype='beddb'
+        filetype = 'beddb'
         return (to_import, filetype)
+
     elif filetype == 'bedpe':
         if no_upload:
             raise Exception("Bedpe files need to be aggregated and cannot be linked. Consider not using the --link-file option", file=sys.stderr)
@@ -118,20 +167,22 @@ def aggregate_file(filename, filetype, assembly, chromsizes_filename, has_header
         output_file = op.join(tmp_dir, filename + '.bed2ddb')
 
         print("Aggregating bedpe (output_file: {}".format(output_file))
-        cca._bedpe(filename,
-                output_file,
-                assembly,
-                importance_column='random',
-                has_header=has_header,
-                chromosome=None,
-                max_per_tile=50,
-                chromsizes_filename=chromsizes_filename,
-                tile_size=1024)
+        cca._bedpe(
+            filename,
+            output_file,
+            assembly,
+            importance_column='random',
+            has_header=has_header,
+            chromosome=None,
+            max_per_tile=50,
+            chromsizes_filename=chromsizes_filename,
+            tile_size=1024
+        )
 
         to_import = output_file
 
         # because we aggregated the file, the new filetype is beddb
-        filetype='bed2ddb'
+        filetype = 'bed2ddb'
         return (to_import, filetype)
     else:
         return (filename, filetype)

--- a/higlass_manage/logs.py
+++ b/higlass_manage/logs.py
@@ -3,17 +3,15 @@ import os.path as op
 
 from higlass_manage.common import get_data_dir
 
+
 @click.command()
-@click.argument('hg_name', nargs=-1)
+@click.option(
+    '-n', '--hg_name',
+    default='default')
 def logs(hg_name):
     '''
-    Return the error log for this container
+    Return the error log for a container
     '''
-    if len(hg_name) == 0:
-        hg_name = 'default'
-    else:
-        hg_name = hg_name[0]
-
     data_dir = get_data_dir(hg_name)
     log_location = op.join(data_dir, 'log', 'hgs.log')
 

--- a/higlass_manage/shell.py
+++ b/higlass_manage/shell.py
@@ -4,20 +4,17 @@ import subprocess as sp
 
 from higlass_manage.common import hg_name_to_container_name
 
+
 @click.command()
-@click.argument('hg-name', nargs=-1)
+@click.option(
+    '-n', '--hg_name',
+    default='default')
 def shell(hg_name):
     '''
-    Start a shell in a higlass container
+    Start a shell in a HiGlass container
     '''
-    if len(hg_name) == 0:
-        hg_name = 'default'
-    else:
-        hg_name = hg_name[0]
-
     client = docker.from_env()
     container_name = hg_name_to_container_name(hg_name)
     container = client.containers.get(container_name)
 
     sp.run(['docker', 'exec', '-it', container_name, 'bash'])
-    

--- a/higlass_manage/start.py
+++ b/higlass_manage/start.py
@@ -8,121 +8,149 @@ import slugid
 import sys
 import time
 
-from higlass_manage.common import CONTAINER_PREFIX, NETWORK_PREFIX, REDIS_PREFIX, REDIS_CONF
+from higlass_manage.common import (
+    CONTAINER_PREFIX, NETWORK_PREFIX, REDIS_PREFIX, REDIS_CONF
+)
+
 
 @click.command()
-@click.option('-t', '--temp-dir',
-        default='/tmp/higlass-docker',
-        help='The temp directory to use',
-        type=str)
-@click.option('-d', '--data-dir',
-        default='~/hg-data',
-        help='The higlass data directory to use',
-        type=str)
-@click.option('-v', '--version',
-        default='latest',
-        help='The version of the Docker container to use (or "local" for images built locally using higlass-docker)',
-        type=str)
-@click.option('-p', '--port',
-        default=8989,
-        help='The port that the HiGlass instance should run on',
-        type=str)
-@click.option('-n', '--hg-name',
-        default='default',
-        help='The name for this higlass instance',
-        type=str)
-@click.option('-s', '--site-url',
-        default=None,
-        help='When creating an external-facing instance, enter its IP or hostname using this parameter',
-        type=str)
-@click.option('-m', '--media-dir',
-        default=None,
-        help='Use a specific media directory for uploaded files',
-        type=str)
-@click.option('--public-data/--no-public-data',
-        default=True,
-        help='Include or exclude public data in the list of available tilesets')
-@click.option('--default-track-options',
-        default=None,
-        help="Specify a json file containing default track options")
-@click.option('--workers',
-        default=None,
-        help="Specify a custom number of workers for the uWSGI application server")
-@click.option('--use-redis',
-              is_flag=True,
-              help="Initialize a Redis-based caching service and bind higlass instance to it")
-@click.option('--redis-dir',
-              default='~/redis-data',
-              help='Use a specific directory for Redis files',
-              type=str)
-@click.option('--hg-repository',
-              default='higlass/higlass-docker',
-              help='The Docker repository to use for the HiGlass image',
-              type=str)
-@click.option('--redis-repository',
-              default='redis',
-              help='The Docker repository to use for the Redis image',
-              type=str)
-@click.option('--redis-tag',
-              default='5.0.3-alpine',
-              help='The Docker tag to use for the Redis image repository',
-              type=str)
-@click.option('--redis-port',
-              default=6379,
-              help='The port to use for the Redis image',
-              type=int)
-def start(temp_dir,
-          data_dir,
-          version,
-          port,
-          hg_name,
-          site_url,
-          media_dir,
-          public_data,
-          default_track_options,
-          workers,
-          use_redis,
-          redis_dir,
-          hg_repository,
-          redis_repository,
-          redis_tag,
-          redis_port):
-    _start(temp_dir,
-           data_dir,
-           version,
-           port,
-           hg_name,
-           site_url,
-           media_dir,
-           public_data,
-           default_track_options,
-           workers,
-           use_redis,
-           redis_dir,
-           hg_repository,
-           redis_repository,
-           redis_tag,
-           redis_port)
-def _start(temp_dir='/tmp/higlass-docker', 
-           data_dir='~/hg-data', 
-           version='latest', 
-           port=8989, 
-           hg_name='default', 
-           site_url=None,
-           media_dir=None, 
-           public_data=True,
-           default_track_options=None,
-           workers=None,
-           use_redis=False,
-           redis_dir='~/redis-data',
-           hg_repository='higlass/higlass-docker',
-           redis_repository='redis',
-           redis_tag='5.0.3-alpine',
-           redis_port=6379):
+@click.argument(
+    'data-dir',
+    type=str)
+@click.option(
+    '-n', '--hg-name',
+    default='default',
+    help='The name for this HiGlass instance',
+    type=str)
+@click.option(
+    '-p', '--port',
+    default=8989,
+    help='The port that the HiGlass instance should run on',
+    type=str)
+@click.option(
+    '-t', '--temp-dir',
+    default='/tmp/higlass-docker',
+    help='The temp directory to use',
+    type=str)
+@click.option(
+    '-v', '--version',
+    default='latest',
+    help='The version of the Docker container to use (or "local" for images built locally using higlass-docker)',
+    type=str)
+@click.option(
+    '-s', '--site-url',
+    default=None,
+    help='When creating an external-facing instance, enter its IP or hostname using this parameter',
+    type=str)
+@click.option(
+    '-m', '--media-dir',
+    default=None,
+    help='Use a specific media directory for uploaded files. The default location is {data-dir}/media/uploads.',
+    type=str)
+@click.option(
+    '--public-data/--no-public-data',
+    default=True,
+    help='Include or exclude public data in the list of available tilesets')
+@click.option(
+    '--default-track-options',
+    default=None,
+    help="Specify a json file containing default track options")
+@click.option(
+    '--workers',
+    default=None,
+    help="Specify a custom number of workers for the uWSGI application server")
+@click.option(
+    '--use-redis',
+    is_flag=True,
+    help="Initialize a Redis-based caching service and bind higlass instance to it")
+@click.option(
+    '--redis-dir',
+    help='Use a specific directory for Redis files',
+    type=str)
+@click.option(
+    '--hg-repository',
+    default='higlass/higlass-docker',
+    help='The Docker repository to use for the HiGlass image',
+    type=str)
+@click.option(
+    '--redis-repository',
+    default='redis',
+    help='The Docker repository to use for the Redis image',
+    type=str)
+@click.option(
+    '--redis-tag',
+    default='5.0.3-alpine',
+    help='The Docker tag to use for the Redis image repository',
+    type=str)
+@click.option(
+    '--redis-port',
+    default=6379,
+    help='The port to use for the Redis image',
+    type=int)
+def start(
+    data_dir,
+    hg_name,
+    port,
+    temp_dir,
+    version,
+    site_url,
+    media_dir,
+    public_data,
+    default_track_options,
+    workers,
+    use_redis,
+    redis_dir,
+    hg_repository,
+    redis_repository,
+    redis_tag,
+    redis_port
+):
+    """
+    Start a HiGlass instance
+
+    """
+    _start(
+        data_dir,
+        hg_name,
+        port,
+        temp_dir,
+        version,
+        site_url,
+        media_dir,
+        public_data,
+        default_track_options,
+        workers,
+        use_redis,
+        redis_dir,
+        hg_repository,
+        redis_repository,
+        redis_tag,
+        redis_port
+    )
+
+
+def _start(
+    data_dir,
+    hg_name='default',
+    port=8989,
+    temp_dir='/tmp/higlass-docker',
+    version='latest',
+    site_url=None,
+    media_dir=None,
+    public_data=True,
+    default_track_options=None,
+    workers=None,
+    use_redis=False,
+    redis_dir=None,
+    hg_repository='higlass/higlass-docker',
+    redis_repository='redis',
+    redis_tag='5.0.3-alpine',
+    redis_port=6379
+):
     '''
     Start a HiGlass instance
     '''
-    hg_container_name = '{}-{}'.format(CONTAINER_PREFIX,hg_name)
+    hg_container_name = '{}-{}'.format(CONTAINER_PREFIX, hg_name)
 
     client = docker.from_env()
 
@@ -152,7 +180,7 @@ def _start(temp_dir='/tmp/higlass-docker',
                 network.remove()
         except docker.errors.APIError:
             sys.stderr.write("Error: Could not access Docker network list to remove existing network.\n")
-            sys.exit(-1)            
+            sys.exit(-1)
 
         try:
             # https://docker-py.readthedocs.io/en/stable/networks.html
@@ -192,8 +220,8 @@ def _start(temp_dir='/tmp/higlass-docker',
             sys.exit(-1)
 
         redis_volumes = {
-            redis_dir : { 'bind' : '/data', 'mode' : 'rw' },
-            redis_conf : { 'bind' : REDIS_CONF, 'mode' : 'rw' }
+            redis_dir: {'bind': '/data', 'mode': 'rw'},
+            redis_conf: {'bind': REDIS_CONF, 'mode': 'rw'}
         }
 
         redis_command = 'redis-server {}'.format(REDIS_CONF)
@@ -225,8 +253,8 @@ def _start(temp_dir='/tmp/higlass-docker',
         sys.stderr.write("done\n")
         sys.stderr.flush()
 
-    data_dir = op.expanduser(data_dir)
-    temp_dir = op.expanduser(temp_dir)
+    data_dir = op.realpath(op.expanduser(data_dir))
+    temp_dir = op.realpath(op.expanduser(temp_dir))
 
     if not op.exists(temp_dir):
         os.makedirs(temp_dir)
@@ -244,21 +272,20 @@ def _start(temp_dir='/tmp/higlass-docker',
     sys.stderr.write('Data directory: {}\n'.format(data_dir))
     sys.stderr.write('Temp directory: ()\n'.format(temp_dir))
 
-    hg_version_addition = '' if version is None else ':{}'.format(version)
-
     sys.stderr.write('Starting... {} {}\n'.format(hg_name, port))
-    hg_volumes={
-        temp_dir : { 'bind' : '/tmp', 'mode' : 'rw' },
-        data_dir : { 'bind' : '/data', 'mode' : 'rw' }
+    hg_volumes = {
+        temp_dir: {'bind': '/tmp', 'mode': 'rw'},
+        data_dir: {'bind': '/data', 'mode': 'rw'}
         }
 
-    if media_dir:
-        hg_volumes[media_dir] = { 'bind' : '/media', 'mode' : 'rw' }
+    if media_dir is not None:
+        media_dir = os.realpath(os.expanduser(media_dir))
+        hg_volumes[media_dir] = {'bind': '/media', 'mode': 'rw'}
         hg_environment['HIGLASS_MEDIA_ROOT'] = '/media'
 
     if not use_redis:
         hg_container = client.containers.run(hg_image,
-                                             ports={80 : port},
+                                             ports={80: port},
                                              volumes=hg_volumes,
                                              name=hg_container_name,
                                              environment=hg_environment,
@@ -270,13 +297,13 @@ def _start(temp_dir='/tmp/higlass-docker',
         # run the higlass container on the shared network with the Redis container
         hg_container = client.containers.run(hg_image,
                                              network=network_name,
-                                             ports={80 : port},
+                                             ports={80: port},
                                              volumes=hg_volumes,
                                              name=hg_container_name,
                                              environment=hg_environment,
                                              publish_all_ports=True,
                                              detach=True)
-        
+
     sys.stderr.write('Docker started: {}\n'.format(hg_container_name))
 
     started = False
@@ -285,8 +312,10 @@ def _start(temp_dir='/tmp/higlass-docker',
         try:
             sys.stderr.write("sending request {}\n".format(counter))
             counter += 1
-            req = requests.get('http://localhost:{}/api/v1/viewconfs/?d=default'.format(port), 
-                    timeout=5)
+            req = requests.get(
+                'http://localhost:{}/api/v1/viewconfs/?d=default'.format(port),
+                timeout=5
+            )
             # sys.stderr.write("request returned {} {}\n".format(req.status_code, req.content))
 
             if req.status_code != 200:
@@ -310,8 +339,8 @@ def _start(temp_dir='/tmp/higlass-docker',
 
         sed_command = """bash -c 'cp higlass-app/static/js/main.*.chunk.js higlass-app/static/js/main.{}.chunk.js'""".format(new_hash)
 
-        ret = hg_container.exec_run(sed_command)   
-             
+        ret = hg_container.exec_run(sed_command)
+
     if not public_data:
         config = json.loads(req.content.decode('utf-8'))
         config['trackSourceServers'] = ['/api/v1']
@@ -353,6 +382,5 @@ def _start(temp_dir='/tmp/higlass-docker',
     ret = hg_container.exec_run(sed_command)
     # sys.stderr.write("ret: {}\n".format(ret))
     sys.stderr.write("Replaced js file\n")
-
 
     sys.stderr.write("Started\n")

--- a/higlass_manage/stop.py
+++ b/higlass_manage/stop.py
@@ -4,6 +4,7 @@ import docker
 
 from .common import CONTAINER_PREFIX, NETWORK_PREFIX, REDIS_PREFIX
 
+
 @click.command()
 @click.argument('names', nargs=-1)
 def stop(names):
@@ -23,7 +24,7 @@ def stop(names):
             client.containers.get(hm_name).remove()
         except docker.errors.NotFound as ex:
             sys.stderr.write("Instance not running: {}\n".format(name))
-            
+
         # redis container
         redis_name = '{}-{}'.format(REDIS_PREFIX, name)
         try:
@@ -31,7 +32,7 @@ def stop(names):
             client.containers.get(redis_name).remove()
         except docker.errors.NotFound:
             sys.stderr.write("No Redis instances found at {}; skipping...\n".format(redis_name))
-            
+
         # bridge network
         network_name = '{}-{}'.format(NETWORK_PREFIX, name)
         try:
@@ -41,4 +42,3 @@ def stop(names):
                 network.remove()
         except docker.errors.NotFound:
             sys.stderr.write("No bridge network found at {}; skipping...\n".format(network_name))
-        

--- a/higlass_manage/view.py
+++ b/higlass_manage/view.py
@@ -16,25 +16,55 @@ from higlass_manage.common import datatype_to_tracktype
 from higlass_manage.start import _start
 from higlass_manage.ingest import _ingest
 
+
 @click.command()
 @click.argument('filename', nargs=1)
-@click.option('-n', '--hg-name',
-        default='default',
-        help='The name for this higlass instance',
-        type=str)
-@click.option('--filetype', default=None, help="The type of file to ingest (e.g. cooler)")
-@click.option('--datatype', default=None, help="The data type of in the input file (e.g. matrix)")
-@click.option('--tracktype', default=None, help="The track type used to view this file")
-@click.option('--position', default=None, help="The position in the view to place this track")
-@click.option('--public-data/--no-public-data',
-        default=True,
-        help='Include or exclude public data in the list of available tilesets')
-@click.option('--assembly', default=None, help="The assembly that this data is mapped to")
-@click.option('--chromsizes-filename', default=None, help="A set of chromosome sizes to use for bed and bedpe files")
-def view(filename, hg_name, filetype, datatype, tracktype, position, public_data, 
-        assembly, chromsizes_filename):
+@click.option(
+    '-n', '--hg-name',
+    default='default',
+    help='The name for this higlass instance',
+    type=str)
+@click.option(
+    '--filetype',
+    default=None,
+    help="The type of file to ingest (e.g. cooler)")
+@click.option(
+    '--datatype',
+    default=None,
+    help="The data type of in the input file (e.g. matrix)")
+@click.option(
+    '--tracktype',
+    default=None,
+    help="The track type used to view this file")
+@click.option(
+    '--position',
+    default=None,
+    help="The position in the view to place this track")
+@click.option(
+    '--public-data/--no-public-data',
+    default=True,
+    help='Include or exclude public data in the list of available tilesets')
+@click.option(
+    '--assembly',
+    default=None,
+    help="The assembly that this data is mapped to")
+@click.option(
+    '--chromsizes-filename',
+    default=None,
+    help="A set of chromosome sizes to use for bed and bedpe files")
+def view(
+    filename,
+    hg_name,
+    filetype,
+    datatype,
+    tracktype,
+    position,
+    public_data,
+    assembly,
+    chromsizes_filename
+):
     '''
-    View a file in higlass.
+    View a file in HiGlass.
 
     The user can specify an instance to view it in. If one is
     not specified the default will be used. If the default isn't
@@ -71,9 +101,9 @@ def view(filename, hg_name, filetype, datatype, tracktype, position, public_data
         return
 
     try:
-        MAX_TILESETS=100000
+        MAX_TILESETS = 100000
         req = requests.get('http://localhost:{}/api/v1/tilesets/?limit={}'.format(port, MAX_TILESETS), timeout=10)
-        
+
         tilesets = json.loads(req.content)
 
         for tileset in tilesets['results']:
@@ -104,8 +134,10 @@ def view(filename, hg_name, filetype, datatype, tracktype, position, public_data
 
     if uuid is None:
         # we haven't found a matching tileset so we need to ingest this one
-        uuid = _ingest(filename, hg_name, filetype, datatype, assembly=assembly,
-                chromsizes_filename=chromsizes_filename)
+        uuid = _ingest(
+            filename, hg_name, filetype, datatype, assembly=assembly,
+            chromsizes_filename=chromsizes_filename
+        )
 
     if uuid is None:
         # couldn't ingest the file
@@ -118,7 +150,7 @@ def view(filename, hg_name, filetype, datatype, tracktype, position, public_data
 
     if tracktype is None and position is None:
         (tracktype, position) = datatype_to_tracktype(datatype)
-        
+
         if tracktype is None:
             print("ERROR: Unknown track type for the given datatype:", datatype)
             return
@@ -143,8 +175,10 @@ def view(filename, hg_name, filetype, datatype, tracktype, position, public_data
         conf['trackSourceServers'] += ['http://higlass.io/api/v1/']
 
     # uplaod the viewconf
-    res = requests.post('http://localhost:{}/api/v1/viewconfs/'.format(port),
-            json={'viewconf': conf})
+    res = requests.post(
+        'http://localhost:{}/api/v1/viewconfs/'.format(port),
+        json={'viewconf': conf}
+    )
 
     if res.status_code != 200:
         print("Error posting viewconf:", res.status, res.content)


### PR DESCRIPTION
## Description

Someone types `higlass-manage start` and expects to see help text because they're too lazy to type `--help`, but instead it pulls a 2GB docker image and runs a container in a directory that isn't clearly advertised.

What was changed in this pull request?

* `higlass-manage start` requires a data directory as argument
* Make `-n`, `--hg-name` a consistent option to all relevant commands.
* Turn `version` into an option.
* Some code formatting.

Why is it necessary?

A command with no arguments shouldn't have side-effects. 

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Updated CHANGELOG.md
